### PR TITLE
Fix box sizing and line height

### DIFF
--- a/csphotoselector.css
+++ b/csphotoselector.css
@@ -18,6 +18,13 @@
 	font-size: 11px;
 	background: rgba(0,0,0,.9);
 }
+#CSPhotoSelector,
+#CSPhotoSelector * {
+	box-sizing: content-box;
+	-moz-box-sizing: content-box;
+	-webkit-box-sizing: content-box;
+	line-height: normal;
+}
 #CSPhotoSelector a,
 #CSPhotoSelector a:active,
 #CSPhotoSelector a:hover,


### PR DESCRIPTION
If the containing page messes with either the box sizing mode or line height, then the dialog layout gets messed up, with photos overflowing the box. This fixes those rules within the dialog.
