### PR TITLE
Exclude empty albums

### DIFF
--- a/csphotoselector.js
+++ b/csphotoselector.js
@@ -8,7 +8,7 @@ var CSPhotoSelector = (function(module, $) {
 	var init, setAlbums, getAlbums, getAlbumById, getPhotoById, setPhotos, newInstance,
 
 	// Private variables
-	settings, albums, prev,
+	settings, albums, prev, photos,
 	$albums, $photos, $container, $albumsContainer, $photosContainer, $selectedCount, $selectedCountMax, $pageNumber, $pageNumberTotal, $pagePrev, $pageNext, $buttonClose, $buttonOK, $buttonCancel,
 
 	// Private functions
@@ -594,7 +594,9 @@ var CSPhotoSelector = (function(module, $) {
 	buildPhotoSelector = function(callback, albumId) {
 		var buildSecondMarkup, buildPhotoMarkup;
 		log("buildPhotoSelector");
-		
+
+		photos = [];
+
 		FB.api('/'+ albumId +'/photos?fields=id,picture,source,height,width&limit=500', function(response) {
 			if (response.data) {
 				setPhotos(response.data);


### PR DESCRIPTION
If you have an empty album (possible, since all users have a 'Timeline Photos' album which can be empty), the selector still shows it. When you select it, the behavior of the photo loader (retry when we have zero photos) means an infinite loop.

Or rather, it just crashes since you never initialize the 'photos' variable. So that's in here too. If you opened an album first, then switched to an empty one, the empty one would incorrectly show the contents of the first album.
