### PR TITLE
Set img max-width to none, fix when images are set to responsive

### DIFF
--- a/csphotoselector.css
+++ b/csphotoselector.css
@@ -32,6 +32,9 @@
 	text-decoration: none;
 	color: #3B5998;
 }
+#CSPhotoSelector img {
+	max-width: none;
+}
 #CSPhotoSelector p,
 #CSPhotoSelector ul,
 #CSPhotoSelector li {


### PR DESCRIPTION
Some frameworks specify `max-width:100%` on images so they display well on mobile. This messes up the thumbnails that scale imgs beyond 100%.
