### PR TITLE
Get all the different image representations

### DIFF
--- a/csphotoselector.js
+++ b/csphotoselector.js
@@ -591,7 +591,7 @@ var CSPhotoSelector = (function(module, $) {
 
 		photos = [];
 
-		FB.api('/'+ albumId +'/photos?fields=id,picture,source,height,width&limit=500', function(response) {
+		FB.api('/'+ albumId +'/photos?fields=id,picture,source,height,width,images&limit=500', function(response) {
 			if (response.data) {
 				setPhotos(response.data);
 				// Build the markup


### PR DESCRIPTION
This is a small change to return all the image representations of a picture. Helpful when trying to get the actual original source for an image.
