### PR TITLE
Responsive support

### DIFF
--- a/csphotoselector.css
+++ b/csphotoselector.css
@@ -286,10 +286,10 @@
  */
 @media screen and (max-width: 480px) {
   #CSPhotoSelector {
-       padding: 0;
-       margin: 0;
-       position: absolute;
-       align-items: center;
+    padding: 0;
+    margin: 0;
+    position: absolute;
+    align-items: center;
   }
   #CSPhotoSelector .CSPhotoSelector_dialog {
     display: block;

--- a/csphotoselector.css
+++ b/csphotoselector.css
@@ -278,3 +278,41 @@
 .CSPhoto_container_active {
   left: 11px;
 }
+
+/* responsive support */
+/* optimized for iPhone 5 and upper
+ * will produce a 1-column albums list
+ * and a 2-columns photos list
+ */
+@media screen and (max-width: 480px) {
+  #CSPhotoSelector {
+       padding: 0;
+       margin: 0;
+       position: absolute;
+       align-items: center;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog {
+    display: block;
+    align-items: center;
+    width: 300px;
+    margin: 0 auto;
+    margin-top: 10%;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog .CSPhotoSelector_photosContainer {
+    height: 315px;
+    overflow: scroll;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog .CSAlbum_container .CSPhotoSelector_album {
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog .CSPhotoSelector_content.CSPhotoSelector_wrapper.CSPhoto_container_active {
+    width: 278px;
+    top: 42px;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog .CSPhoto_container .CSPhotoSelector_photo {
+    width: 117px;
+    height: 86px;
+  }
+}

--- a/csphotoselector.js
+++ b/csphotoselector.js
@@ -8,7 +8,7 @@ var CSPhotoSelector = (function(module, $) {
 	var init, setAlbums, getAlbums, getAlbumById, getPhotoById, setPhotos, newInstance,
 
 	// Private variables
-	settings, albums, prev, photos, photosOfYouCover,
+	settings, albums, prev, photos,
 	$albums, $photos, $container, $albumsContainer, $photosContainer, $selectedCount, $selectedCountMax, $pageNumber, $pageNumberTotal, $pagePrev, $pageNext, $buttonClose, $buttonOK, $buttonCancel,
 
 	// Private functions
@@ -76,25 +76,16 @@ var CSPhotoSelector = (function(module, $) {
 	 * If your website has already loaded the user's Facebook photos, pass them in here to avoid another API call.
 	 */
 	setAlbums = function(input) {
-		log('CSPhotoSelector - Setting album')
-		log(input)
 		var i, len;
 		if (!input || input.length === 0) {
 			return;
 		}
 		input = Array.prototype.slice.call(input);
 		input = input.sort(sortPhotos);
-		albums = typeof(albums) == 'undefined' ? [] : albums;
-		// TODO: optimize duplicates search performance
+
+		albums = [];
 		for (var i=0; i<input.length; i++){
-			var duplicate = false;
-			for (var j=0; j<albums.length; j++){
-				if (albums[j].id == input[i].id) {
-					duplicate = true;
-				}
-			}
-			if (!duplicate)
-				albums[albums.length] = input[i];
+			albums[albums.length] = input[i];
 		}
 	};
 
@@ -536,7 +527,7 @@ var CSPhotoSelector = (function(module, $) {
 	 */
 	buildAlbumSelector = function(id, callback) {
 		var buildMarkup, buildAlbumMarkup;
-		log("CSPhotoSelector - Build album " + id);
+		log("buildAlbumSelector");
 		$pagination.show();
 
 		if (!FB) {
@@ -548,54 +539,20 @@ var CSPhotoSelector = (function(module, $) {
 		FB.getLoginStatus(function(response) {
 			if (response.status === 'connected') {
 				var accessToken = response.authResponse.accessToken;
-				var canBuildMarkup = false;
-				var deferredAlbums = new $.Deferred();
-				var deferredMe = new $.Deferred();
-
 				// Load Facebook photos
 				FB.api('/'+ id +'/albums', function(response) {
 					if (response.data.length) {
-						log('CSPhotoSelector - albums list :')
-						log(response.data)
 						setAlbums(response.data);
-						canBuildMarkup = true;
+						// Build the markup
+						buildMarkup(accessToken);
+						// Call the callback
+						if (typeof callback === 'function') { callback(); }
 					} else {
 						alert ('Sorry, your friend won\'t let us look through their photos');
 						log('CSPhotoSelector - buildAlbumSelector - No albums returned');
 						return false;
 					}
-					deferredAlbums.resolve();
-				})
-
-				// Load Facebook "photos photos of me" (tagged picture of me, not part of any album)
-				if (id == 'me') {
-					FB.api('/me/photos?fields=picture&limit=1', function(response) {
-						if (response.data.length) {
-							log('CSPhotoSelector - Photos of You :')
-							log(response.data)
-							setAlbums([{id: 'me', name: 'Photos of You'}]);
-							photosOfYouCover = response.data[0].picture;
-							canBuildMarkup = true;
-						} else {
-							log('CSPhotoSelector - buildAlbumSelector - No "photos of me" returned');
-							return false;
-						}
-						deferredMe.resolve();
-					});
-				} else {
-					deferredMe.resolve();
-				}
-
-				deferredMe.done(function() {
-					if (canBuildMarkup) {
-						log('CSPhotoSelector - Build albums markup')
-						// Build the markup
-						buildMarkup(accessToken);
-						// Call the callback
-						if (typeof callback === 'function') { callback(); }
-					}
 				});
-
 			} else {
 				log('CSPhotoSelector - buildAlbumSelector - User is not logged in to Facebook');
 				return false;
@@ -609,23 +566,14 @@ var CSPhotoSelector = (function(module, $) {
 			for (i = 0, len = albums.length; i < len; i += 1) {
 				html += buildAlbumMarkup(albums[i], accessToken);
 			}
-			log('CSPhotoSelector - Markup built :')
-			log(html)
 			$albums = $(html);
 		};
 
 		// Return the markup for a single album
 		buildAlbumMarkup = function(album, accessToken) {
-			log('CSPhotoSelector - Building markup for album ' + album.id)
-			if (album.id != 'me') {
-			 	var src = 'https://graph.facebook.com/'+ album.id +'/picture?type=album&access_token='+ accessToken;
-			} else {
-				var src = photosOfYouCover;
-			}
-
 			return '<a href="#" class="CSPhotoSelector_album" data-id="' + album.id + '">' +
 					'<div class="CSPhotoSelector_albumWrap"><div>' +
-					'<img src="' + src +'" alt="' + htmlEntities(album.name) + '" class="CSPhotoSelector_photoAvatar" />' +
+					'<img src="https://graph.facebook.com/'+ album.id +'/picture?type=album&access_token='+ accessToken +'" alt="' + htmlEntities(album.name) + '" class="CSPhotoSelector_photoAvatar" />' +
 					'</div></div>' +
 					'<div class="CSPhotoSelector_photoName">' + htmlEntities(album.name) + '</div>' +
 					'</a>';

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         <div class="CSPhotoSelector_form">
           <div class="CSPhotoSelector_header">
               <a href="#" id="CSPhotoSelector_buttonClose">x</a>
-              <p>{{ 'facebook.photoselector.choose'|trans|raw }}</p>
+              <p>Choose from Photos</p>
           </div>
           <div class="CSPhotoSelector_content CSAlbumSelector_wrapper">
             <p>Browse your albums until you find a picture you want to use</p>


### PR DESCRIPTION
Attempts to fix responsive view by producing a 1-column albums list and a 2-columns photos list on iPhone 5 and larger.

Related issues : https://github.com/cshold/jQuery-Facebook-Photo-Selector/issues/25 and https://github.com/cshold/jQuery-Facebook-Photo-Selector/issues/16

Screenshots (project name blurred on purpose):

![Albums view](https://files.not.live/Monosnap_2016-05-12_02-03-45.png)

![Photos view](https://files.not.live/Monosnap_2016-05-12_02-03-05.png)

