### PR TITLE
Feature: "Photos of You" album

### DIFF
--- a/csphotoselector.css
+++ b/csphotoselector.css
@@ -286,10 +286,10 @@
  */
 @media screen and (max-width: 480px) {
   #CSPhotoSelector {
-       padding: 0;
-       margin: 0;
-       position: absolute;
-       align-items: center;
+    padding: 0;
+    margin: 0;
+    position: absolute;
+    align-items: center;
   }
   #CSPhotoSelector .CSPhotoSelector_dialog {
     display: block;

--- a/csphotoselector.css
+++ b/csphotoselector.css
@@ -278,3 +278,41 @@
 .CSPhoto_container_active {
   left: 11px;
 }
+
+/* responsive support */
+/* optimized for iPhone 5 and upper
+ * will produce a 1-column albums list
+ * and a 2-columns photos list
+ */
+@media screen and (max-width: 480px) {
+  #CSPhotoSelector {
+       padding: 0;
+       margin: 0;
+       position: absolute;
+       align-items: center;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog {
+    display: block;
+    align-items: center;
+    width: 300px;
+    margin: 0 auto;
+    margin-top: 10%;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog .CSPhotoSelector_photosContainer {
+    height: 315px;
+    overflow: scroll;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog .CSAlbum_container .CSPhotoSelector_album {
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog .CSPhotoSelector_content.CSPhotoSelector_wrapper.CSPhoto_container_active {
+    width: 278px;
+    top: 42px;
+  }
+  #CSPhotoSelector .CSPhotoSelector_dialog .CSPhoto_container .CSPhotoSelector_photo {
+    width: 117px;
+    height: 86px;
+  }
+}

--- a/csphotoselector.css
+++ b/csphotoselector.css
@@ -284,7 +284,7 @@
  * will produce a 1-column albums list
  * and a 2-columns photos list
  */
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 650px) {
   #CSPhotoSelector {
     padding: 0;
     margin: 0;

--- a/index.html
+++ b/index.html
@@ -60,12 +60,11 @@
     <!-- Markup for Carson Shold's Photo Selector -->
     <div id="CSPhotoSelector">
       <div class="CSPhotoSelector_dialog">
-        <a href="#" id="CSPhotoSelector_buttonClose">x</a>
         <div class="CSPhotoSelector_form">
           <div class="CSPhotoSelector_header">
-            <p>Choose from Photos</p>
+              <a href="#" id="CSPhotoSelector_buttonClose">x</a>
+              <p>{{ 'facebook.photoselector.choose'|trans|raw }}</p>
           </div>
-
           <div class="CSPhotoSelector_content CSAlbumSelector_wrapper">
             <p>Browse your albums until you find a picture you want to use</p>
             <div class="CSPhotoSelector_searchContainer CSPhotoSelector_clearfix">


### PR DESCRIPTION
# What this feature solves
When you have been tagged on photos by your friends, the pictures will go in a fake "Photos of You" album in your Facebook photos index (these are pictures that you did not upload _yourself_ only): 

![Photos of You album](https://files.not.live/Monosnap_2016-05-12_05-38-29.png)

Because CSPhotoSelector pulls photos from albums, the said tagged pictures will not appear in the photo browser because they aren't part of a _real_ album.

This feature does not require new permissions, as photos you're tagged in are part of the `photos` permission:

![Permissions](https://files.not.live/Monosnap_2016-05-12_05-39-09.png)

# How this feature changes user experience

This pull requests introduces the **a new album called "Photos of You"**, displayed only if public tagged pictures of you (`/me` in Facebook's API) are available. This fresh album will take the first tagged photo as main picture:

![Photos of You inside CSPS](https://files.not.live/Monosnap_2016-05-12_06-11-44.png)

When one enters the album the list of available photos is displayed, like a regular album.

Feel free to comment!

---

_Sidenote: I initially created this feature in the master brach, after my previous pull request about mediaqueries (https://github.com/cshold/jQuery-Facebook-Photo-Selector/pull/26). So commits e0adf62, 0ecb174, and 5ab141d are also part of the pull request._